### PR TITLE
Reduce notifications for staging

### DIFF
--- a/forms/aws/cloudwatch.tf
+++ b/forms/aws/cloudwatch.tf
@@ -217,8 +217,6 @@ resource "aws_cloudwatch_event_rule" "codedeploy_sns" {
     ],
     "detail": {
       "state": [
-        "START",
-        "SUCCESS",
         "FAILURE"
       ]
     }


### PR DESCRIPTION
# Summary | Résumé

This PR removes the notification in Slack for deployments that have started or are successful in the Staging environment.  Deployment failures still raise alerts through Slack.