### PR TITLE
Set default security group for vpc

### DIFF
--- a/forms/aws/networking.tf
+++ b/forms/aws/networking.tf
@@ -234,6 +234,10 @@ resource "aws_route_table_association" "forms_private_route" {
 # AWS Security Groups
 ###
 
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.forms.id
+}
+
 resource "aws_security_group" "forms" {
   name        = "forms"
   description = "Ingress - Forms"


### PR DESCRIPTION
This PR creates a default VPC security group with no ingress of egress rules (block by default).
This fixes [Issue 102 SRE](https://github.com/cds-snc/site-reliability-engineering-internal/issues/102)
