### PR TITLE
Save submission logic

### DIFF
--- a/forms/aws/ecr.tf
+++ b/forms/aws/ecr.tf
@@ -7,7 +7,7 @@ resource "aws_ecr_repository" "viewer_repository" {
   name = local.image_name
 
   #Ignore tag mutability for Staging
-  image_tag_mutability = "MUTABLE" #tfsec:ignoreAWS078
+  image_tag_mutability = "MUTABLE" #tfsec:ignore:AWS078
 
   image_scanning_configuration {
     scan_on_push = true

--- a/forms/aws/ecr.tf
+++ b/forms/aws/ecr.tf
@@ -3,10 +3,11 @@ locals {
 }
 
 resource "aws_ecr_repository" "viewer_repository" {
-  #Ignore tag mutability for Staging
-  #tfsec:ignoreAWS078
+
   name                 = local.image_name
-  image_tag_mutability = "MUTABLE"
+  
+  #Ignore tag mutability for Staging
+  image_tag_mutability = "MUTABLE" #tfsec:ignoreAWS078
 
   image_scanning_configuration {
     scan_on_push = true

--- a/forms/aws/ecr.tf
+++ b/forms/aws/ecr.tf
@@ -4,8 +4,8 @@ locals {
 
 resource "aws_ecr_repository" "viewer_repository" {
 
-  name                 = local.image_name
-  
+  name = local.image_name
+
   #Ignore tag mutability for Staging
   image_tag_mutability = "MUTABLE" #tfsec:ignoreAWS078
 

--- a/forms/aws/ecr.tf
+++ b/forms/aws/ecr.tf
@@ -3,6 +3,8 @@ locals {
 }
 
 resource "aws_ecr_repository" "viewer_repository" {
+  #Ignore tag mutability for Staging
+  #tfsec:ignoreAWS078
   name                 = local.image_name
   image_tag_mutability = "MUTABLE"
 

--- a/forms/aws/lambda.tf
+++ b/forms/aws/lambda.tf
@@ -255,6 +255,7 @@ resource "aws_iam_policy" "lambda_dynamodb" {
       "Action": [
         "dynamodb:GetItem",
         "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
         "dynamodb:DeleteItem",
         "dynamodb:Scan",
         "dynamodb:Query"

--- a/forms/aws/lambda/reliability/lib/dataLayer.js
+++ b/forms/aws/lambda/reliability/lib/dataLayer.js
@@ -8,8 +8,6 @@ module.exports = function extractFormData(submission) {
     const question = formOrigin.elements.find((element) => element.id === qID);
     if (question) {
       handleType(question, formResponses[question.id], dataCollector);
-    } else {
-      console.error(`Failed component ID look up ${qID} on form ID ${formOrigin.id}`);
     }
   });
   return dataCollector;
@@ -34,6 +32,7 @@ function handleType(question, response, collector) {
       handleDynamicForm(qTitle, response, question.properties.subElements, collector);
       break;
     case "fileInput":
+      handleTextResponse(qTitle, response, collector);
       break;
   }
 }

--- a/forms/aws/lambda/reliability/lib/dataLayer.js
+++ b/forms/aws/lambda/reliability/lib/dataLayer.js
@@ -82,7 +82,7 @@ function handleArrayResponse(title, response, collector) {
 }
 
 function handleTextResponse(title, response, collector) {
-  if (response !== undefined && response !== null) {
+  if (response !== undefined && response !== null && response !== "") {
     collector.push(`${title}${String.fromCharCode(13)}-${response}`);
     return;
   }

--- a/forms/aws/lambda/reliability/reliability.js
+++ b/forms/aws/lambda/reliability/reliability.js
@@ -86,7 +86,7 @@ async function getSubmission(message) {
       Key: {
         SubmissionID: { S: message.submissionID },
       },
-      ProjectExpression: "SubmissionID,SendReceipt,Data",
+      ProjectExpression: "SubmissionID,SendReceipt,FormData",
     };
     //save data to DynamoDB
     return db.send(new GetItemCommand(DBParams));

--- a/forms/aws/lambda/reliability/reliability.js
+++ b/forms/aws/lambda/reliability/reliability.js
@@ -15,6 +15,7 @@ exports.handler = async function (event) {
       }))
       .catch((err) => {
         console.error("Could not sucessfully retrieve data");
+        console.error(err);
         throw Error(err);
       });
     submissionIDPlaceholder = submissionID;
@@ -73,40 +74,31 @@ exports.handler = async function (event) {
     }
   } catch (err) {
     console.error(`Error in processing, submission ${submissionIDPlaceholder} not processed.`);
-    // By rethrowing the error below the message will not be deleted from the queue.
-    throw Error(err);
+    return { statusCode: 500, body: "Could not process / Function Error" };
   }
 };
 
 async function getSubmission(message) {
-  try {
-    const db = new DynamoDBClient({ region: REGION });
-    const DBParams = {
-      TableName: "ReliabilityQueue",
-      Key: {
-        SubmissionID: { S: message.submissionID },
-      },
-      ProjectExpression: "SubmissionID,SendReceipt,FormData",
-    };
-    //save data to DynamoDB
-    return db.send(new GetItemCommand(DBParams));
-  } catch (err) {
-    throw Error(err);
-  }
+  const db = new DynamoDBClient({ region: REGION });
+  const DBParams = {
+    TableName: "ReliabilityQueue",
+    Key: {
+      SubmissionID: { S: message.submissionID },
+    },
+    ProjectExpression: "SubmissionID,SendReceipt,FormData",
+  };
+  //save data to DynamoDB
+  return db.send(new GetItemCommand(DBParams));
 }
 
 async function removeSubmission(message) {
-  try {
-    const db = new DynamoDBClient({ region: REGION });
-    const DBParams = {
-      TableName: "ReliabilityQueue",
-      Key: {
-        SubmissionID: { S: message.submissionID },
-      },
-    };
-    //remove data fron DynamoDB
-    return db.send(new DeleteItemCommand(DBParams));
-  } catch (err) {
-    throw Error(err);
-  }
+  const db = new DynamoDBClient({ region: REGION });
+  const DBParams = {
+    TableName: "ReliabilityQueue",
+    Key: {
+      SubmissionID: { S: message.submissionID },
+    },
+  };
+  //remove data fron DynamoDB
+  return db.send(new DeleteItemCommand(DBParams));
 }

--- a/forms/aws/lambda/reliability/reliability.js
+++ b/forms/aws/lambda/reliability/reliability.js
@@ -83,9 +83,8 @@ async function getSubmission(message) {
     const db = new DynamoDBClient({ region: REGION });
     const DBParams = {
       TableName: "ReliabilityQueue",
-      //prettier-ignore
       Key: {
-        SubmissionID: { "S": message.submissionID },
+        SubmissionID: { S: message.submissionID },
       },
       ProjectExpression: "SubmissionID,SendReceipt,FormData",
     };

--- a/forms/aws/lambda/reliability/reliability.js
+++ b/forms/aws/lambda/reliability/reliability.js
@@ -11,7 +11,7 @@ exports.handler = async function (event) {
       .then((messageData) => ({
         submissionID: messageData.Item.SubmissionID.S,
         sendReceipt: messageData.Item.SendReceipt.S,
-        formSubmission: JSON.parse(messageData.Item.Data.S) || null,
+        formSubmission: JSON.parse(messageData.Item.FormData.S) || null,
       }))
       .catch((err) => {
         console.error("Could not sucessfully retrieve data");

--- a/forms/aws/lambda/reliability/reliability.js
+++ b/forms/aws/lambda/reliability/reliability.js
@@ -83,8 +83,9 @@ async function getSubmission(message) {
     const db = new DynamoDBClient({ region: REGION });
     const DBParams = {
       TableName: "ReliabilityQueue",
+      //prettier-ignore
       Key: {
-        SubmissionID: { S: message.submissionID },
+        SubmissionID: { "S": message.submissionID },
       },
       ProjectExpression: "SubmissionID,SendReceipt,FormData",
     };

--- a/forms/aws/lambda/submission/submission.js
+++ b/forms/aws/lambda/submission/submission.js
@@ -55,20 +55,16 @@ const sendData = async (submissionID) => {
 };
 
 const saveData = async (submissionID, formData) => {
-  try {
-    const DBParams = {
-      TableName: "ReliabilityQueue",
-      Item: {
-        SubmissionID: { S: submissionID },
-        SendReceipt: { S: "unknown" },
-        FormData: { S: JSON.stringify(formData) },
-      },
-    };
-    //save data to DynamoDB
-    await db.send(new PutItemCommand(DBParams));
-  } catch (err) {
-    throw Error(err);
-  }
+  const DBParams = {
+    TableName: "ReliabilityQueue",
+    Item: {
+      SubmissionID: { S: submissionID },
+      SendReceipt: { S: "unknown" },
+      FormData: { S: JSON.stringify(formData) },
+    },
+  };
+  //save data to DynamoDB
+  await db.send(new PutItemCommand(DBParams));
 };
 
 const saveReceipt = async (submissionID, receiptID) => {

--- a/forms/aws/lambda/submission/submission.js
+++ b/forms/aws/lambda/submission/submission.js
@@ -80,14 +80,12 @@ const saveReceipt = async (submissionID, receiptID) => {
         SubmissionID: { S: submissionID },
       },
       UpdateExpression: "SET SendReceipt = :receipt",
-      // prettier-ignore
       ExpressionAttributeValues: {
-        ":receipt": { "S": receiptID },
+        ":receipt": { S: receiptID },
       },
     };
     //save data to DynamoDB
     await db.send(new UpdateItemCommand(DBParams));
-    await db.update();
   } catch (err) {
     console.warn(`Unable to update receipt ID on submissionID: ${submissionID}`);
     console.warn(err);

--- a/forms/aws/lambda/submission/submission.js
+++ b/forms/aws/lambda/submission/submission.js
@@ -72,7 +72,6 @@ const saveData = async (submissionID, formData) => {
 };
 
 const saveReceipt = async (submissionID, receiptID) => {
-  // Need to research and fix this command
   try {
     const DBParams = {
       TableName: "ReliabilityQueue",

--- a/forms/aws/sqs.tf
+++ b/forms/aws/sqs.tf
@@ -2,7 +2,7 @@
 
 resource "aws_sqs_queue" "reliability_queue" {
   name                        = "submission_processing.fifo"
-  delay_seconds               = 0
+  delay_seconds               = 5
   max_message_size            = 2048
   message_retention_seconds   = 345600
   fifo_queue                  = true


### PR DESCRIPTION
# Summary | Résumé

This PR modifies the logic around form submission processing at the SQS entry point.
Previous Logic:
Send uuid to sqs -> Get receipt and save with submission data in DB
New Logic:
Save submission to DB -> Send uuid to SQS -> Update submission DB item with sqs receipt

This will prevent race conditions from happening when saving to the DB.  A delay of 5 seconds has also been introduced before the SQS will process the event to aid in mitigating race conditions on saving the sqs receipt to the DB.