### PR TITLE
Support custom email subject, if provided in the form JSON config

### DIFF
--- a/forms/aws/lambda/reliability/lib/markdown.js
+++ b/forms/aws/lambda/reliability/lib/markdown.js
@@ -2,7 +2,15 @@ const json2md = require("json2md");
 const extractFormData = require("dataLayer");
 
 module.exports = (formResponse) => {
-  const title = `${formResponse.form.titleEn} / ${formResponse.form.titleFr}`;
+  const subjectEn = formResponse.form.emailSubjectEn
+    ? formResponse.form.emailSubjectEn
+    : formResponse.form.titleEn;
+  const subjectFr = formResponse.form.emailSubjectFr
+    ? formResponse.form.emailSubjectFr
+    : formResponse.form.titleFr;
+
+  const title = `${subjectEn} / ${subjectFr}`;
+
   const stringifiedData = extractFormData(formResponse);
   const mdBody = stringifiedData.map((item) => {
     return { p: item };

--- a/forms/aws/lambda/reliability/reliability.js
+++ b/forms/aws/lambda/reliability/reliability.js
@@ -1,4 +1,8 @@
-const { DynamoDBClient, GetItemCommand, DeleteItemCommand } = require("@aws-sdk/client-dynamodb");
+const {
+  DynamoDBClient,
+  GetItemCommand,
+  DeleteItemCommand,
+} = require("@aws-sdk/client-dynamodb");
 const { NotifyClient } = require("notifications-node-client");
 const convertMessage = require("markdown");
 const REGION = process.env.REGION;
@@ -7,7 +11,9 @@ exports.handler = async function (event) {
   let submissionIDPlaceholder = "";
   try {
     const message = JSON.parse(event.Records[0].body);
-    const { submissionID, sendReceipt, formSubmission } = await getSubmission(message)
+    const { submissionID, sendReceipt, formSubmission } = await getSubmission(
+      message
+    )
       .then((messageData) => ({
         submissionID: messageData.Item.SubmissionID.S,
         sendReceipt: messageData.Item.SendReceipt.S,
@@ -35,7 +41,11 @@ exports.handler = async function (event) {
       process.env.NOTIFY_API_KEY
     );
     const emailBody = convertMessage(formSubmission);
-    const messageSubject = formSubmission.form.titleEn + " Submission";
+    const messageSubject = `${
+      formSubmission.form.emailSubjectEn
+        ? formSubmission.form.emailSubjectEn
+        : formSubmission.form.titleEn
+    } Submission`;
     // Need to get this from the submission now.. not the app.
     const submissionFormat = formSubmission.submission;
     // Send to Notify
@@ -70,10 +80,14 @@ exports.handler = async function (event) {
 
       return { statusCode: 202, body: "Received by Notify" };
     } else {
-      throw Error("Form can not be submitted due to missing Submission Parameters");
+      throw Error(
+        "Form can not be submitted due to missing Submission Parameters"
+      );
     }
   } catch (err) {
-    console.error(`Error in processing, submission ${submissionIDPlaceholder} not processed.`);
+    console.error(
+      `Error in processing, submission ${submissionIDPlaceholder} not processed.`
+    );
     return { statusCode: 500, body: "Could not process / Function Error" };
   }
 };


### PR DESCRIPTION
# Summary | Résumé

Applying the changes done in the NextJS app to support customizing the email subject line, if provided in the form's JSON config: https://github.com/cds-snc/platform-forms-client/pull/170

Note: Prettier was applied to the files, let's chat if we need to align formatting?