### PR TITLE
ignore warning about using global encryption key

### DIFF
--- a/bootstrap/provider.tf
+++ b/bootstrap/provider.tf
@@ -45,6 +45,8 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
     type = "S"
   }
   #tfsec:ignore:AWS086
+  # Ignore using global encryption key
+  #tfsec:ignore:AWS092
 
   tags = {
     ("CostCentre") = "Forms"

--- a/forms/aws/ecr.tf
+++ b/forms/aws/ecr.tf
@@ -8,6 +8,8 @@ resource "aws_ecr_repository" "viewer_repository" {
 
   #Ignore tag mutability for Staging
   image_tag_mutability = "MUTABLE" #tfsec:ignore:AWS078
+  # Ignore using global encryption key
+  #tfsec:ignore:AWS093
 
   image_scanning_configuration {
     scan_on_push = true

--- a/forms/aws/secrets.tf
+++ b/forms/aws/secrets.tf
@@ -6,7 +6,8 @@ resource "aws_secretsmanager_secret" "notify_api_key" {
   name                    = "notify_api_key"
   recovery_window_in_days = 0
 }
-
+# Ignore using global encryption key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret_version" "notify_api_key" {
   secret_id     = aws_secretsmanager_secret.notify_api_key.id
   secret_string = var.ecs_secret_notify_api_key

--- a/forms/aws/secrets.tf
+++ b/forms/aws/secrets.tf
@@ -5,9 +5,10 @@
 resource "aws_secretsmanager_secret" "notify_api_key" {
   name                    = "notify_api_key"
   recovery_window_in_days = 0
+  # Ignore using global encryption key
+  #tfsec:ignore:AWS095
 }
-# Ignore using global encryption key
-#tfsec:ignore:AWS095
+
 resource "aws_secretsmanager_secret_version" "notify_api_key" {
   secret_id     = aws_secretsmanager_secret.notify_api_key.id
   secret_string = var.ecs_secret_notify_api_key


### PR DESCRIPTION
# Summary | Résumé

This PR ignores the terraform security scan suggestions to use customer managed encryption keys for Secrets Manager, Dynamo DB keeping terraform state, and ECR.

The current settings leverage AWS's default encryption key.  This can be looked at in the future if needed for protected data.
