### PR TITLE
S3 reliability queue

### DIFF
--- a/bootstrap/provider.tf
+++ b/bootstrap/provider.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region = "ca-central-1"
 }
-
+#tfsec:ignore:AWS002 tfsec:ignore:AWS077
 resource "aws_s3_bucket" "log_bucket" {
   bucket = join("", [var.storage_bucket, "-logs"])
   acl    = "log-delivery-write"
@@ -12,8 +12,7 @@ resource "aws_s3_bucket" "log_bucket" {
       }
     }
   }
-  #tfsec:ignore:AWS002
-  #tfsec:ignore:AWS077
+
 }
 
 resource "aws_s3_bucket_public_access_block" "log_bucket" {
@@ -50,7 +49,7 @@ resource "aws_s3_bucket_public_access_block" "storage_bucket" {
   ignore_public_acls = true
   restrict_public_buckets = true
 }
-
+#tfsec:ignore:AWS086 tfsec:ignore:AWS092
 resource "aws_dynamodb_table" "terraform_state_lock" {
   name           = "terraform-lock"
   read_capacity  = 5
@@ -60,9 +59,7 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
     name = "LockID"
     type = "S"
   }
-  #tfsec:ignore:AWS086
-  # Ignore using global encryption key
-  #tfsec:ignore:AWS092
+
 
   tags = {
     ("CostCentre") = "Forms"

--- a/forms/aws/ecr.tf
+++ b/forms/aws/ecr.tf
@@ -2,14 +2,14 @@ locals {
   image_name = "form_viewer_${var.environment}"
 }
 
+# Ignore using global encryption key
+#tfsec:ignore:AWS093
 resource "aws_ecr_repository" "viewer_repository" {
 
   name = local.image_name
 
   #Ignore tag mutability for Staging
   image_tag_mutability = "MUTABLE" #tfsec:ignore:AWS078
-  # Ignore using global encryption key
-  #tfsec:ignore:AWS093
 
   image_scanning_configuration {
     scan_on_push = true

--- a/forms/aws/ecs.tf
+++ b/forms/aws/ecs.tf
@@ -228,7 +228,7 @@ data "aws_iam_policy_document" "forms_s3" {
     ]
 
     resources = [
-      aws_s3_bucket.reliability_file_storage
+      aws_s3_bucket.reliability_file_storage.arn
     ]
   }
 }

--- a/forms/aws/ecs.tf
+++ b/forms/aws/ecs.tf
@@ -29,21 +29,22 @@ data "template_file" "form_viewer_task" {
   template = file("task-definitions/form_viewer.json")
 
   vars = {
-    image                 = local.form_viewer_repo
-    awslogs-group         = aws_cloudwatch_log_group.forms.name
-    awslogs-region        = var.region
-    awslogs-stream-prefix = "ecs-${var.ecs_form_viewer_name}"
-    metric_provider       = var.metric_provider
-    tracer_provider       = var.tracer_provider
-    notify_api_key        = aws_secretsmanager_secret_version.notify_api_key.arn
-    google_client_id      = aws_secretsmanager_secret_version.google_client_id.arn
-    google_client_secret  = aws_secretsmanager_secret_version.google_client_secret.arn
-    database_url          = aws_secretsmanager_secret_version.database_url.arn
-    redis_url             = aws_elasticache_replication_group.redis.primary_endpoint_address
-    nextauth_url          = "https://${var.route53_zone_name}"
-    submission_api        = aws_lambda_function.submission.arn
-    templates_api         = aws_lambda_function.templates.arn
-    organisations_api     = aws_lambda_function.organisations.arn
+    image                    = local.form_viewer_repo
+    awslogs-group            = aws_cloudwatch_log_group.forms.name
+    awslogs-region           = var.region
+    awslogs-stream-prefix    = "ecs-${var.ecs_form_viewer_name}"
+    metric_provider          = var.metric_provider
+    tracer_provider          = var.tracer_provider
+    notify_api_key           = aws_secretsmanager_secret_version.notify_api_key.arn
+    google_client_id         = aws_secretsmanager_secret_version.google_client_id.arn
+    google_client_secret     = aws_secretsmanager_secret_version.google_client_secret.arn
+    database_url             = aws_secretsmanager_secret_version.database_url.arn
+    redis_url                = aws_elasticache_replication_group.redis.primary_endpoint_address
+    nextauth_url             = "https://${var.route53_zone_name}"
+    submission_api           = aws_lambda_function.submission.arn
+    templates_api            = aws_lambda_function.templates.arn
+    organisations_api        = aws_lambda_function.organisations.arn
+    reliability_file_storage = aws_s3_bucket.reliability_file_storage.id
   }
 }
 
@@ -208,6 +209,31 @@ data "aws_iam_policy_document" "forms_secrets_manager" {
   }
 }
 
+
+resource "aws_iam_policy" "forms_s3" {
+  name   = "formsS3Access"
+  path   = "/"
+  policy = data.aws_iam_policy_document.forms_s3.json
+}
+
+data "aws_iam_policy_document" "forms_s3" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket"
+    ]
+
+    resources = [
+      aws_s3_bucket.reliability_file_storage
+    ]
+  }
+}
+
+
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_forms" {
   role       = aws_iam_role.forms.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
@@ -217,3 +243,4 @@ resource "aws_iam_role_policy_attachment" "secrets_manager_forms" {
   role       = aws_iam_role.forms.name
   policy_arn = aws_iam_policy.forms_secrets_manager.arn
 }
+

--- a/forms/aws/lambda.tf
+++ b/forms/aws/lambda.tf
@@ -568,6 +568,35 @@ resource "aws_iam_policy" "lambda_secrets" {
 EOF
 }
 
+# Allow lambda to access S3 buckets
+
+resource "aws_iam_policy" "lambda_s3" {
+  name        = "lambda_dynamobdb"
+  path        = "/"
+  description = "IAM policy for storing files in S3"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.reliability_file_storage.arn}",
+        "${aws_s3_bucket.vault_file_storage.arn}",
+        "${aws_s3_bucket.archive_storage.arn}
+        ],
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
 resource "aws_iam_role_policy_attachment" "lambda_secrets" {
   role       = aws_iam_role.iam_for_lambda.name
   policy_arn = aws_iam_policy.lambda_secrets.arn

--- a/forms/aws/lambda.tf
+++ b/forms/aws/lambda.tf
@@ -408,6 +408,7 @@ resource "aws_lambda_permission" "internal_templates" {
 
 ## Allow Lambda to create Logs in Cloudwatch
 
+#tfsec:ignore:AWS099
 resource "aws_iam_policy" "lambda_logging" {
   name        = "lambda_logging"
   path        = "/"
@@ -431,6 +432,7 @@ resource "aws_iam_policy" "lambda_logging" {
 EOF
 }
 
+#tfsec:ignore:AWS099
 resource "aws_iam_policy" "lambda_rds" {
   name        = "lambda_rds"
   path        = "/"
@@ -472,6 +474,7 @@ resource "aws_iam_policy" "lambda_rds" {
 }
 
 ## Allow Lambda to create and retrieve SQS messages
+#tfsec:ignore:AWS099
 resource "aws_iam_policy" "lambda_sqs" {
   name        = "lambda_sqs"
   path        = "/"

--- a/forms/aws/lambda.tf
+++ b/forms/aws/lambda.tf
@@ -27,6 +27,7 @@ data "archive_file" "notify_slack" {
   output_path = "/tmp/notify_slack.zip"
 }
 
+#tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "notify_slack_sns" {
   filename      = "/tmp/notify_slack.zip"
   function_name = "NotifySlackSNS"
@@ -42,7 +43,6 @@ resource "aws_lambda_function" "notify_slack_sns" {
       SLACK_WEBHOOK = var.slack_webhook
     }
   }
-
 }
 ###
 # AWS Lambda - Reliability Queue Processing
@@ -85,6 +85,7 @@ data "archive_file" "reliability_nodejs" {
   output_path = "/tmp/reliability_nodejs.zip"
 }
 
+#tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "reliability" {
   filename      = "/tmp/reliability_main.zip"
   function_name = "Reliability"
@@ -142,6 +143,7 @@ data "archive_file" "submission_lib" {
   output_path = "/tmp/submission_lib.zip"
 }
 
+#tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "submission" {
   filename      = "/tmp/submission_main.zip"
   function_name = "Submission"
@@ -186,6 +188,7 @@ data "archive_file" "templates_lib" {
   output_path = "/tmp/templates_lib.zip"
 }
 
+#tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "templates" {
   filename      = "/tmp/templates_main.zip"
   function_name = "Templates"
@@ -230,6 +233,7 @@ data "archive_file" "organisations_lib" {
   output_path = "/tmp/organisations_lib.zip"
 }
 
+#tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "organisations" {
   filename      = "/tmp/organisations_main.zip"
   function_name = "Organisations"
@@ -276,6 +280,7 @@ data "archive_file" "retrieval_lib" {
   output_path = "/tmp/retrieval_lib.zip"
 }
 
+#tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "retrieval" {
   filename      = "/tmp/retrieval_main.zip"
   function_name = "Retrieval"
@@ -312,6 +317,7 @@ data "archive_file" "load_testing" {
   output_path = "/tmp/load_testing.zip"
 }
 
+#tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "load_testing" {
   filename         = "/tmp/load_testing.zip"
   function_name    = "LoadTesting"

--- a/forms/aws/rds.tf
+++ b/forms/aws/rds.tf
@@ -12,8 +12,9 @@ resource "aws_db_subnet_group" "forms" {
     Name                  = var.rds_db_subnet_group_name
     (var.billing_tag_key) = var.billing_tag_value
   }
-}
-
+}  
+# KMS key is not explicitly defined but a default key is created
+#tfsec:ignore:AWS051
 resource "aws_rds_cluster" "forms" {
   cluster_identifier        = "${var.rds_name}-cluster"
   engine                    = "aurora-postgresql"
@@ -27,8 +28,7 @@ resource "aws_rds_cluster" "forms" {
   preferred_backup_window   = "07:00-09:00"
   db_subnet_group_name      = aws_db_subnet_group.forms.name
   storage_encrypted         = true
-  #tfsec:ignore:AWS051
-  # KMS key is not explicitly defined but a default key is created
+
 
   scaling_configuration {
     auto_pause   = false

--- a/forms/aws/rds.tf
+++ b/forms/aws/rds.tf
@@ -12,7 +12,7 @@ resource "aws_db_subnet_group" "forms" {
     Name                  = var.rds_db_subnet_group_name
     (var.billing_tag_key) = var.billing_tag_value
   }
-}  
+}
 # KMS key is not explicitly defined but a default key is created
 #tfsec:ignore:AWS051
 resource "aws_rds_cluster" "forms" {

--- a/forms/aws/redis.tf
+++ b/forms/aws/redis.tf
@@ -1,7 +1,7 @@
-  # Ignore that there is no encryption in transit or at rest.
-  # Only non sensistive data is stored in feature flags
-  #tfsec:ignore:AWS035 tfsec:ignore:AWS036
-  resource "aws_elasticache_replication_group" "redis" {
+# Ignore that there is no encryption in transit or at rest.
+# Only non sensistive data is stored in feature flags
+#tfsec:ignore:AWS035 tfsec:ignore:AWS036
+resource "aws_elasticache_replication_group" "redis" {
   automatic_failover_enabled    = true
   replication_group_id          = "gcforms-redis-rep-group"
   replication_group_description = "Redis cluster for GCForms"

--- a/forms/aws/redis.tf
+++ b/forms/aws/redis.tf
@@ -1,8 +1,7 @@
-resource "aws_elasticache_replication_group" "redis" {
   # Ignore that there is no encryption in transit or at rest.
   # Only non sensistive data is stored in feature flags
-  #tfsec:ignore:AWS035
-  #tfsec:ignore:AWS036
+  #tfsec:ignore:AWS035 tfsec:ignore:AWS036
+  resource "aws_elasticache_replication_group" "redis" {
   automatic_failover_enabled    = true
   replication_group_id          = "gcforms-redis-rep-group"
   replication_group_description = "Redis cluster for GCForms"

--- a/forms/aws/s3.tf
+++ b/forms/aws/s3.tf
@@ -1,6 +1,7 @@
 ###
 # AWS S3 bucket - WAF log target
-###
+###  
+#tfsec:ignore:AWS002 tfsec:ignore:AWS077
 resource "aws_s3_bucket" "firehose_waf_logs" {
   bucket = "forms-staging-terraform-waf-logs"
   acl    = "private"
@@ -11,9 +12,6 @@ resource "aws_s3_bucket" "firehose_waf_logs" {
       }
     }
   }
-  #tfsec:ignore:AWS002
-  #tfsec:ignore:AWS077
-
 }
 
 resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {
@@ -28,6 +26,7 @@ resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {
 ###
 # AWS S3 bucket - Reliability Queue File Storage
 ###
+#tfsec:ignore:AWS002 tfsec:ignore:AWS077
 resource "aws_s3_bucket" "reliability_file_storage" {
   bucket = "forms-staging-reliability_file_storage"
   acl    = "private"
@@ -46,9 +45,6 @@ resource "aws_s3_bucket" "reliability_file_storage" {
       }
     }
   }
-  #tfsec:ignore:AWS002
-  #tfsec:ignore:AWS077
-
 }
 
 resource "aws_s3_bucket_public_access_block" "reliability_file_storage" {
@@ -62,6 +58,7 @@ resource "aws_s3_bucket_public_access_block" "reliability_file_storage" {
 ###
 # AWS S3 bucket - Vault File Storage
 ###
+#tfsec:ignore:AWS002 tfsec:ignore:AWS077
 resource "aws_s3_bucket" "vault_file_storage" {
   bucket = "forms-staging-vault_file_storage"
   acl    = "private"
@@ -72,9 +69,6 @@ resource "aws_s3_bucket" "vault_file_storage" {
       }
     }
   }
-  #tfsec:ignore:AWS002
-  #tfsec:ignore:AWS077
-
 }
 
 resource "aws_s3_bucket_public_access_block" "vault_file_storage" {
@@ -88,6 +82,7 @@ resource "aws_s3_bucket_public_access_block" "vault_file_storage" {
 ###
 # AWS S3 bucket - Archive Storage
 ###
+#tfsec:ignore:AWS002 tfsec:ignore:AWS077
 resource "aws_s3_bucket" "archive_storage" {
   bucket = "forms-staging-archive_storage"
   acl    = "private"
@@ -105,9 +100,6 @@ resource "aws_s3_bucket" "archive_storage" {
       }
     }
   }
-  #tfsec:ignore:AWS002
-  #tfsec:ignore:AWS077
-
 }
 
 resource "aws_s3_bucket_public_access_block" "archive_storage" {

--- a/forms/aws/s3.tf
+++ b/forms/aws/s3.tf
@@ -95,7 +95,7 @@ resource "aws_s3_bucket" "archive_storage" {
   lifecycle_rule {
     enabled = true
     expiration {
-      days = 5
+      days = 30
     }
   }
   server_side_encryption_configuration {

--- a/forms/aws/s3.tf
+++ b/forms/aws/s3.tf
@@ -23,3 +23,97 @@ resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+
+###
+# AWS S3 bucket - Reliability Queue File Storage
+###
+resource "aws_s3_bucket" "reliability_file_storage" {
+  bucket = "forms-staging-reliability_file_storage"
+  acl    = "private"
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 5
+    }
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  #tfsec:ignore:AWS002
+  #tfsec:ignore:AWS077
+
+}
+
+resource "aws_s3_bucket_public_access_block" "reliability_file_storage" {
+  bucket                  = aws_s3_bucket.reliability_file_storage.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+###
+# AWS S3 bucket - Vault File Storage
+###
+resource "aws_s3_bucket" "vault_file_storage" {
+  bucket = "forms-staging-vault_file_storage"
+  acl    = "private"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  #tfsec:ignore:AWS002
+  #tfsec:ignore:AWS077
+
+}
+
+resource "aws_s3_bucket_public_access_block" "vault_file_storage" {
+  bucket                  = aws_s3_bucket.vault_file_storage.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+###
+# AWS S3 bucket - Archive Storage
+###
+resource "aws_s3_bucket" "archive_storage" {
+  bucket = "forms-staging-archive_storage"
+  acl    = "private"
+
+  lifecycle_rule {
+    enabled = true
+    expiration {
+      days = 5
+    }
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  #tfsec:ignore:AWS002
+  #tfsec:ignore:AWS077
+
+}
+
+resource "aws_s3_bucket_public_access_block" "archive_storage" {
+  bucket                  = aws_s3_bucket.archive_storage.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/forms/aws/secrets.tf
+++ b/forms/aws/secrets.tf
@@ -1,12 +1,11 @@
 ###
 # AWS Secret Manager - Forms
-###
-
+###  
+# Ignore using global encryption key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "notify_api_key" {
   name                    = "notify_api_key"
   recovery_window_in_days = 0
-  # Ignore using global encryption key
-  #tfsec:ignore:AWS095
 }
 
 resource "aws_secretsmanager_secret_version" "notify_api_key" {
@@ -14,11 +13,11 @@ resource "aws_secretsmanager_secret_version" "notify_api_key" {
   secret_string = var.ecs_secret_notify_api_key
 }
 
+# Ignore using global encryption key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "google_client_id" {
   name                    = "google_client_id"
   recovery_window_in_days = 0
-  # Ignore using global encryption key
-  #tfsec:ignore:AWS095
 }
 
 resource "aws_secretsmanager_secret_version" "google_client_id" {
@@ -26,11 +25,11 @@ resource "aws_secretsmanager_secret_version" "google_client_id" {
   secret_string = var.ecs_secret_google_client_id
 }
 
+# Ignore using global encryption key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "google_client_secret" {
   name                    = "google_client_secret"
   recovery_window_in_days = 0
-  # Ignore using global encryption key
-  #tfsec:ignore:AWS095
 }
 
 resource "aws_secretsmanager_secret_version" "google_client_secret" {
@@ -38,11 +37,11 @@ resource "aws_secretsmanager_secret_version" "google_client_secret" {
   secret_string = var.ecs_secret_google_client_secret
 }
 
+# Ignore using global encryption key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "database_url" {
   name                    = "server-database-url"
   recovery_window_in_days = 0
-  # Ignore using global encryption key
-  #tfsec:ignore:AWS095
 }
 
 resource "aws_secretsmanager_secret_version" "database_url" {
@@ -50,11 +49,11 @@ resource "aws_secretsmanager_secret_version" "database_url" {
   secret_string = "postgres://${var.rds_db_user}:${var.rds_db_password}@${aws_rds_cluster.forms.endpoint}:5432/${var.rds_db_name}"
 }
 
+# Ignore using global encryption key
+#tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "database_secret" {
   name                    = "database-secret"
   recovery_window_in_days = 0
-  # Ignore using global encryption key
-  #tfsec:ignore:AWS095
 }
 
 

--- a/forms/aws/task-definitions/form_viewer.json
+++ b/forms/aws/task-definitions/form_viewer.json
@@ -48,6 +48,10 @@
       {
         "name": "REDIS_URL",
         "value": "${redis_url}"
+      },
+      {
+        "name": "RELIABILITY_FILE_STORAGE",
+        "value": "${reliability_file_storage}"
       }
     ],
     "secrets": [

--- a/forms/aws/vpc_flow_log.tf
+++ b/forms/aws/vpc_flow_log.tf
@@ -31,6 +31,7 @@ resource "aws_iam_role" "vpc_flow_logs" {
 EOF
 }
 
+#tfsec:ignore:AWS099
 resource "aws_iam_role_policy" "vpc_flow_logs" {
   name = "vpc_flow_logs"
   role = aws_iam_role.vpc_flow_logs.id


### PR DESCRIPTION
# Summary | Résumé

This PR creates 3 S3 buckets:
- reliability_file_storage: to store file attachments while form submissions are being processed through the reliability queue.  File will auto delete after 5 days.
- vault_file_storage: to store file attachments after a form has been processed and sent to the vault.
- archive_storage: to store file submissions and file attachments for up to 30 days in case recovery efforts are required.