### PR TITLE
Remove egress from ECS to Internet

### DIFF
--- a/forms/aws/ecs.tf
+++ b/forms/aws/ecs.tf
@@ -91,7 +91,6 @@ resource "aws_ecs_service" "form_viewer" {
     subnets          = aws_subnet.forms_private.*.id
     security_groups = [
       aws_security_group.forms.id,
-      aws_security_group.forms_egress.id
     ]
   }
 

--- a/forms/aws/networking.tf
+++ b/forms/aws/networking.tf
@@ -370,26 +370,6 @@ resource "aws_security_group" "forms_load_balancer" {
   }
 }
 
-resource "aws_security_group" "forms_egress" {
-  name        = "egress-anywhere"
-  description = "Egress - Forms External Services"
-  vpc_id      = aws_vpc.forms.id
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-  }
-}
-
-resource "aws_security_group_rule" "forms_egress_notify" {
-  description       = "Security group rule for Forms Notify egress"
-  type              = "egress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.forms_egress.id
-  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007
-}
-
 resource "aws_security_group" "privatelink" {
   name        = "privatelink"
   description = "privatelink endpoints"


### PR DESCRIPTION
# Summary | Résumé
This PR removes the egress rule that allowed outbound traffic from the ECS task to the internet.  This was a remanent from the source projects infrastructure (Covid Portal) that required the rule for outbound information to New Relic.
This current project does not require such access.

Closes #42 