### PR TITLE
feat: add Terraform devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+
+ARG USERNAME=vscode
+
+# Set these in devcontainer.json
+ARG TERRAFORM_VERSION
+ARG TERRAGRUNT_VERSION
+
+# Install packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends awscli ca-certificates curl git gnupg2 jq make openssh-client python3-pip vim zsh \
+    && apt-get autoremove -y && apt-get clean -y 
+
+# Install Terraform
+RUN curl -Lo terraform.zip https://releases.hashicorp.com/terraform/"${TERRAFORM_VERSION}"/terraform_"${TERRAFORM_VERSION}"_linux_"$(dpkg --print-architecture)".zip \
+    && unzip terraform.zip \
+    && mv terraform /usr/local/bin/ \
+    && rm terraform.zip
+
+# Install Terragrunt
+RUN curl -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v"${TERRAGRUNT_VERSION}"/terragrunt_linux_"$(dpkg --print-architecture)" \
+    && chmod +x terragrunt \
+    && mv terragrunt /usr/local/bin/
+
+# Install Checkov
+RUN pip3 install --upgrade requests setuptools \
+    && pip3 install --upgrade botocore checkov
+
+# Setup aliases and autocomplete
+RUN echo "\n\
+complete -C /usr/bin/aws_completer aws\n\
+complete -C /usr/local/bin/terraform terraform\n\
+complete -C /usr/local/bin/terraform terragrunt\n\
+alias tf='terraform'\n\
+alias tg='terragrunt'\n\
+alias ll='la -la'" >> /home/"${USERNAME}"/.zshrc

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,39 @@
+# Setup
+1. [SSH keys](#SSH-keys)
+1. [GPG commit signing](#GPG-commit-signing)
+
+## SSH keys
+To make your keys available in the devcontainer, you'll need:
+1. the `ssh-agent` running on the host; and
+2. your key(s) added to it.
+
+To make this happen:
+1. Auto-start the ssh-agent:
+```sh
+# Update ~/.bashrc or ~/.zshrc
+[ -z "$SSH_AUTH_SOCK" ] && eval "$(ssh-agent -s)"
+```
+2. Add your key:
+```sh
+# Update ~/.ssh/config
+Host *
+	UseKeychain yes
+	AddKeysToAgent yes
+	IdentityFile ~/.ssh/<PRIVATE_KEY>
+
+# Or manually add the key
+ssh-add -K ~/.ssh/<PRIVATE_KEY>
+```
+
+## GPG commit signing
+You'll need a [graphical pinentry program on Mac/Windows](https://github.com/microsoft/vscode-remote-release/issues/3168#issuecomment-654637826) to capture your GPG key's password.  On your host:
+```sh
+brew install pinentry-mac
+echo "pinentry-program /usr/local/bin/pinentry-mac" >> ~/.gnupg/gpg-agent.conf
+gpgconf --kill gpg-agent 		# force a restart to reload the config
+```
+Test in the devcontainer:
+```sh
+gpg --list-secret-keys			# you should see your key(s)
+echo "mello" | gpg --clear-sign	# you should be prompted for your key's password
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+	"name": "Terraform",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": {
+			"TERRAFORM_VERSION": "1.0.10",
+			"TERRAGRUNT_VERSION": "0.35.6"
+		}
+	},
+
+	"containerEnv": {
+		"SHELL": "/bin/zsh"
+	},
+
+	"settings": {
+		"[terraform]": {
+			"editor.formatOnSave": true
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"hashicorp.terraform",
+		"redhat.vscode-yaml"
+	],
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
# Summary
This VS Code devcontainer creates a development environment
for Terraform and Terragrunt work.

# Related
* #28 
* cds-snc/platform-sre-security-support#47