### PR TITLE
fix: limit scope of Terraform GitHub workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "forms/aws/**"
+      - ".github/workflows/terraform.yml"      
   pull_request:
     branches:
       - main
+    paths:
+      - "forms/aws/**"
+      - ".github/workflows/terraform.yml" 
 
 defaults:
   run:


### PR DESCRIPTION
# Summary
This will cause the Terraform plan/apply workflow to only run when the Terraform root module or workflow files have been updated.

The reason for this change is to limit unnecessary Terraform plan/apply runs against the infrastructure as the Terragrunt refactor is performed.

# Related
* #28 
* cds-snc/platform-sre-security-support#47