### PR TITLE
feat: Terragrunt to create the Route53 hosted zone

### DIFF
--- a/.bootstrap/tfstate.tf
+++ b/.bootstrap/tfstate.tf
@@ -18,12 +18,17 @@ variable "tfstate_bucket_name" {
 }
 
 module "state_bucket" {
-  source      = "github.com/cds-snc/terraform-modules?ref=v0.0.38//S3"
-  bucket_name = var.tfstate_bucket_name
+  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.38//S3"
+  bucket_name       = var.tfstate_bucket_name
+  billing_tag_value = "Forms"
+
+  versioning = {
+    enabled = true
+  }
+
   logging = {
     target_bucket = module.state_bucket_logs.s3_bucket_id
   }
-  billing_tag_value = "Forms"
 }
 
 module "state_bucket_logs" {

--- a/.github/workflows/terragrunt-apply-scratch.yml
+++ b/.github/workflows/terragrunt-apply-scratch.yml
@@ -1,0 +1,60 @@
+name: "Terragrunt apply SCRATCH"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "aws/**"
+      - "env/common/**"
+      - "env/scratch/**"
+      - ".github/workflows/terragrunt-apply-scratch.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.SCRATCH_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.SCRATCH_AWS_SECRET_ACCESS_KEY }}
+  TERRAFORM_VERSION: 1.0.10
+  TERRAGRUNT_VERSION: 0.35.6
+  TF_INPUT: false
+
+jobs:
+  terragrunt-apply:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Setup Terragrunt
+        run: |
+          mkdir bin
+          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
+          chmod +x bin/*
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+        id: filter
+        with:
+          filters: |
+            common:
+              - '.github/workflows/terragrunt-plan-scratch.yml'
+              - 'env/common/**'
+              - 'env/terragrunt.hcl'
+              - 'env/scratch/env_vars.hcl'
+            hosted_zone:
+              - 'aws/hosted_zone/**'
+              - 'env/scratch/hosted_zone/**'
+
+      # No dependencies
+      - name: Terragrunt apply hosted_zone
+        if: ${{ steps.filter.outputs.hosted_zone == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/scratch/hosted_zone
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/terragrunt-plan-scratch.yml
+++ b/.github/workflows/terragrunt-plan-scratch.yml
@@ -1,0 +1,73 @@
+name: "Terragrunt plan SCRATCH"
+
+on:
+  pull_request:
+    paths:
+      - "aws/**"
+      - "env/common/**"
+      - "env/scratch/**"
+      - ".github/workflows/terragrunt-apply-scratch.yml"
+
+env:
+  AWS_REGION: ca-central-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.SCRATCH_AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.SCRATCH_AWS_SECRET_ACCESS_KEY }}
+  CONFTEST_VERSION: 0.27.0
+  TERRAFORM_VERSION: 1.0.10
+  TERRAGRUNT_VERSION: 0.35.6
+  TF_INPUT: false
+
+jobs:
+
+  terragrunt-plan:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_wrapper: false
+
+      - name: Setup Terragrunt
+        run: |
+          mkdir bin
+          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
+          chmod +x bin/*
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: Install Conftest
+        run: |
+          wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" \
+          && wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/checksums.txt" \
+          && grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status \
+          && tar -zxvf "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" conftest \
+          && mv conftest /usr/local/bin \
+          && rm "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" checksums.txt          
+
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+        id: filter
+        with:
+          filters: |
+            common:
+              - '.github/workflows/terragrunt-plan-scratch.yml'
+              - 'env/common/**'
+              - 'env/terragrunt.hcl'
+              - 'env/scratch/env_vars.hcl'
+            hosted_zone:
+              - 'aws/hosted_zone/**'
+              - 'env/scratch/hosted_zone/**'
+
+      # No dependencies
+      - name: Terragrunt plan hosted_zone
+        if: ${{ steps.filter.outputs.hosted_zone == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/scratch/hosted_zone"
+          comment-delete: "true"
+          comment-title: "Scratch: hosted_zone"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,11 @@
 *.tfstate
 *.tfstate.*
 
-# terraform dependency lock file
-.terraform.lock.hcl
+# Terraform lock file
+.bootstrap/.terraform.lock.hcl
+
+# Terragrunt
+.terragrunt-cache
 
 # Crash log files
 crash.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+default: help
+
+help:
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##/→/'
+
+checkov: 	## Checkov security static analysis
+	checkov -d aws
+
+fmt: 		## Format all .tf files
+	cd aws &&\
+	terraform fmt -recursive
+
+hclfmt: 	## Format all .hcl files
+	cd env/scratch &&\
+	terragrunt run-all hclfmt
+
+validate: 	## Terragrunt validate all resources
+	cd env/scratch &&\
+	terragrunt run-all validate
+
+.PHONY: \
+	checkov \
+	default \
+	fmt \
+	hclfmt \
+	help \
+	validate

--- a/aws/hosted_zone/hosted_zone.tf
+++ b/aws/hosted_zone/hosted_zone.tf
@@ -7,5 +7,6 @@ resource "aws_route53_zone" "form_viewer" {
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
+    "Terraform"           = true
   }
 }

--- a/aws/hosted_zone/hosted_zone.tf
+++ b/aws/hosted_zone/hosted_zone.tf
@@ -1,0 +1,11 @@
+#
+# Route53 hosted zone:
+# Holds the DNS records for the service
+#
+resource "aws_route53_zone" "form_viewer" {
+  name = var.domain
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}

--- a/env/scratch/hosted_zone/.terraform.lock.hcl
+++ b/env/scratch/hosted_zone/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.63.0"
+  constraints = "3.63.0"
+  hashes = [
+    "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
+    "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
+    "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
+    "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
+    "zh:632cb5e2d9d5041875f57174236eafe5b05dbf26750c1041ab57eb08c5369fe2",
+    "zh:7cfeaf5bde1b28bd010415af1f3dc494680a8374f1a26ec19db494d99938cc4e",
+    "zh:99d871606b67c8aefce49007315de15736b949c09a9f8f29ad8af1e9ce383ed3",
+    "zh:c4fc8539ffe90df5c7ae587fde495fac6bc0186fec2f2713a8988a619cef265f",
+    "zh:d0a26493206575c99ca221d78fe64f96a8fbcebe933af92eea6b39168c1f1c1d",
+    "zh:e156fdc964fdd4a7586ec15629e20d2b06295b46b4962428006e088145db07d6",
+    "zh:eb04fc80f652b5c92f76822f0fec1697581543806244068506aed69e1bb9b2af",
+    "zh:f5638a533cf9444f7d02b5527446cdbc3b2eab8bcc4ec4b0ca32035fe6f479d3",
+  ]
+}

--- a/env/scratch/hosted_zone/terragrunt.hcl
+++ b/env/scratch/hosted_zone/terragrunt.hcl
@@ -1,0 +1,7 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../aws//hosted_zone"
+}

--- a/env/terragrunt.hcl
+++ b/env/terragrunt.hcl
@@ -4,7 +4,7 @@ locals {
 
 inputs = {
   account_id        = "${local.vars.inputs.account_id}"
-  billing_tag_key   = "CostCenter"
+  billing_tag_key   = "CostCentre"
   billing_tag_value = "forms-platform-${local.vars.inputs.env}"   
   domain            = "${local.vars.inputs.domain}"
   env               = "${local.vars.inputs.env}"


### PR DESCRIPTION
# Summary
This hosted zone holds all DNS records required by the Forms service.

Also included:
* Terragrunt plan and apply GitHub workflows
* Fix to `tfstate.tf` S3 remote state to enable versioning.
* Fix to `.gitignore` to allow Terraform lock files.  This allow us 
to pin provider/module versions for consistent Terraform 
plan and apply commands.
* Makefile with common commands. 

# Related
* #28
* cds-snc/platform-sre-security-support#47