### PR TITLE
feat: Terragrunt moodule for DynamDB tables

### DIFF
--- a/.github/workflows/terragrunt-apply-scratch.yml
+++ b/.github/workflows/terragrunt-apply-scratch.yml
@@ -50,6 +50,9 @@ jobs:
               - 'env/common/**'
               - 'env/terragrunt.hcl'
               - 'env/scratch/env_vars.hcl'
+            dynamodb:
+              - 'aws/dynamodb/**'
+              - 'env/scratch/dynamodb/**'              
             hosted_zone:
               - 'aws/hosted_zone/**'
               - 'env/scratch/hosted_zone/**'
@@ -82,6 +85,11 @@ jobs:
         if: ${{ steps.filter.outputs.network == 'true' || steps.filter.outputs.common == 'true' }}
         working-directory: env/scratch/network
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply dynamodb
+        if: ${{ steps.filter.outputs.dynamodb == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/scratch/dynamodb
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve        
 
       # Depends on network
       - name: Terragrunt apply redis

--- a/.github/workflows/terragrunt-plan-scratch.yml
+++ b/.github/workflows/terragrunt-plan-scratch.yml
@@ -58,6 +58,9 @@ jobs:
               - 'env/common/**'
               - 'env/terragrunt.hcl'
               - 'env/scratch/env_vars.hcl'
+            dynamodb:
+              - 'aws/dynamodb/**'
+              - 'env/scratch/dynamodb/**'
             hosted_zone:
               - 'aws/hosted_zone/**'
               - 'env/scratch/hosted_zone/**'
@@ -103,6 +106,16 @@ jobs:
           directory: "env/scratch/network"
           comment-delete: "true"
           comment-title: "Scratch: network"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan dynamodb
+        if: ${{ steps.filter.outputs.dynamodb == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/scratch/dynamodb"
+          comment-delete: "true"
+          comment-title: "Scratch: dynamodb"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 

--- a/aws/dynamodb/dynamo.tf
+++ b/aws/dynamodb/dynamo.tf
@@ -1,0 +1,57 @@
+resource "aws_dynamodb_table" "reliability_queue" {
+  name           = "ReliabilityQueue"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "SubmissionID"
+  stream_enabled = false
+
+  attribute {
+    name = "SubmissionID"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.kms_key_dynamodb_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_dynamodb_table" "vault" {
+  name           = "Vault"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "FormID"
+  range_key      = "SubmissionID"
+  stream_enabled = false
+
+  attribute {
+    name = "FormID"
+    type = "S"
+  }
+
+  attribute {
+    name = "SubmissionID"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.kms_key_dynamodb_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}

--- a/aws/dynamodb/inputs.tf
+++ b/aws/dynamodb/inputs.tf
@@ -1,0 +1,4 @@
+variable "kms_key_dynamodb_arn" {
+  description = "KMS key ARN used to encrypt DynamoDB content"
+  type        = string
+}

--- a/env/scratch/dynamodb/.terraform.lock.hcl
+++ b/env/scratch/dynamodb/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.63.0"
+  constraints = "3.63.0"
+  hashes = [
+    "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
+    "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
+    "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
+    "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
+    "zh:632cb5e2d9d5041875f57174236eafe5b05dbf26750c1041ab57eb08c5369fe2",
+    "zh:7cfeaf5bde1b28bd010415af1f3dc494680a8374f1a26ec19db494d99938cc4e",
+    "zh:99d871606b67c8aefce49007315de15736b949c09a9f8f29ad8af1e9ce383ed3",
+    "zh:c4fc8539ffe90df5c7ae587fde495fac6bc0186fec2f2713a8988a619cef265f",
+    "zh:d0a26493206575c99ca221d78fe64f96a8fbcebe933af92eea6b39168c1f1c1d",
+    "zh:e156fdc964fdd4a7586ec15629e20d2b06295b46b4962428006e088145db07d6",
+    "zh:eb04fc80f652b5c92f76822f0fec1697581543806244068506aed69e1bb9b2af",
+    "zh:f5638a533cf9444f7d02b5527446cdbc3b2eab8bcc4ec4b0ca32035fe6f479d3",
+  ]
+}

--- a/env/scratch/dynamodb/terragrunt.hcl
+++ b/env/scratch/dynamodb/terragrunt.hcl
@@ -1,0 +1,24 @@
+terraform {
+  source = "../../../aws//dynamodb"
+}
+
+dependencies {
+  paths = ["../kms"]
+}
+
+dependency "kms" {
+  config_path = "../kms"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    kms_key_dynamodb_arn = ""
+  }
+}
+
+inputs = {
+  kms_key_dynamodb_arn = dependency.kms.outputs.kms_key_dynamodb_arn
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Creates the reliability queue and vault DynamoDB tables used by Forms.

Original module code:
414146c

# Related
* #28 
* cds-snc/platform-sre-security-support#47