### PR TITLE
feat: Terragrunt Elastic Container Registry

### DIFF
--- a/.github/workflows/terragrunt-apply-scratch.yml
+++ b/.github/workflows/terragrunt-apply-scratch.yml
@@ -52,7 +52,10 @@ jobs:
               - 'env/scratch/env_vars.hcl'
             dynamodb:
               - 'aws/dynamodb/**'
-              - 'env/scratch/dynamodb/**'              
+              - 'env/scratch/dynamodb/**'
+            ecr:
+              - 'aws/ecr/**'
+              - 'env/scratch/ecr/**'
             hosted_zone:
               - 'aws/hosted_zone/**'
               - 'env/scratch/hosted_zone/**'
@@ -80,6 +83,11 @@ jobs:
         working-directory: env/scratch/kms
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Terragrunt apply ecr
+        if: ${{ steps.filter.outputs.ecr == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: env/scratch/ecr
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
       # Depends on kms
       - name: Terragrunt apply network
         if: ${{ steps.filter.outputs.network == 'true' || steps.filter.outputs.common == 'true' }}
@@ -89,7 +97,7 @@ jobs:
       - name: Terragrunt apply dynamodb
         if: ${{ steps.filter.outputs.dynamodb == 'true' || steps.filter.outputs.common == 'true' }}
         working-directory: env/scratch/dynamodb
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve        
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       # Depends on network
       - name: Terragrunt apply redis

--- a/.github/workflows/terragrunt-plan-scratch.yml
+++ b/.github/workflows/terragrunt-plan-scratch.yml
@@ -61,6 +61,9 @@ jobs:
             dynamodb:
               - 'aws/dynamodb/**'
               - 'env/scratch/dynamodb/**'
+            ecr:
+              - 'aws/ecr/**'
+              - 'env/scratch/ecr/**'
             hosted_zone:
               - 'aws/hosted_zone/**'
               - 'env/scratch/hosted_zone/**'
@@ -95,6 +98,16 @@ jobs:
           directory: "env/scratch/kms"
           comment-delete: "true"
           comment-title: "Scratch: kms"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"
+
+      - name: Terragrunt plan ecr
+        if: ${{ steps.filter.outputs.ecr == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "env/scratch/ecr"
+          comment-delete: "true"
+          comment-title: "Scratch: ecr"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
 

--- a/aws/.checkov.yml
+++ b/aws/.checkov.yml
@@ -2,7 +2,9 @@
 
 skip-check:
   - CKV_AWS_23  # Security group descriptions are not required
+  - CKV_AWS_51  # ECR `latest` image tag is used in Staging
   - CKV_AWS_128 # RDS IAM authentication will not be used
+  - CKV_AWS_136 # ECR default service key encryption is acceptable
   - CKV_AWS_162 # RDS IAM authentication will not be used
   - CKV2_AWS_5  # Security groups are attached in seperate Terragrunt modules
   - CKV_AWS_29  # TODO: Elasticache investigate at-rest data encryption

--- a/aws/ecr/ecr.tf
+++ b/aws/ecr/ecr.tf
@@ -1,0 +1,38 @@
+#
+# Elastic Container Registry
+# Holds the Forms app images used by the Elastic Container Service
+#
+resource "aws_ecr_repository" "viewer_repository" {
+  name                 = "form_viewer_${var.env}"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "policy" {
+  repository = aws_ecr_repository.viewer_repository.name
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 30 images"
+
+      selection = {
+        tagStatus     = "tagged"
+        tagPrefixList = ["v"]
+        countType     = "imageCountMoreThan"
+        countNumber   = 30
+      }
+
+      action = {
+        type = "expire"
+      }
+    }]
+  })
+}

--- a/aws/ecr/outputs.tf
+++ b/aws/ecr/outputs.tf
@@ -1,0 +1,4 @@
+output "ecr_repository_url" {
+  description = "URL of the Form viewer ECR"
+  value       = aws_ecr_repository.viewer_repository.repository_url
+}

--- a/env/scratch/ecr/.terraform.lock.hcl
+++ b/env/scratch/ecr/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.63.0"
+  constraints = "3.63.0"
+  hashes = [
+    "h1:v9aPF3aaBpk0uSO5pfggYJKGgP/Ur28hZRJs1jS+ttI=",
+    "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
+    "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
+    "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
+    "zh:632cb5e2d9d5041875f57174236eafe5b05dbf26750c1041ab57eb08c5369fe2",
+    "zh:7cfeaf5bde1b28bd010415af1f3dc494680a8374f1a26ec19db494d99938cc4e",
+    "zh:99d871606b67c8aefce49007315de15736b949c09a9f8f29ad8af1e9ce383ed3",
+    "zh:c4fc8539ffe90df5c7ae587fde495fac6bc0186fec2f2713a8988a619cef265f",
+    "zh:d0a26493206575c99ca221d78fe64f96a8fbcebe933af92eea6b39168c1f1c1d",
+    "zh:e156fdc964fdd4a7586ec15629e20d2b06295b46b4962428006e088145db07d6",
+    "zh:eb04fc80f652b5c92f76822f0fec1697581543806244068506aed69e1bb9b2af",
+    "zh:f5638a533cf9444f7d02b5527446cdbc3b2eab8bcc4ec4b0ca32035fe6f479d3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.1.0"
+  constraints = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/env/scratch/ecr/terragrunt.hcl
+++ b/env/scratch/ecr/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../aws//ecr"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Creates the ECR that holds the Form viewer Docker images
used by the ECS cluster.

Original module code:
5c8f647

# Related
* #28 
* cds-snc/platform-sre-security-support#47