### PR TITLE
fix: ECS S3 IAM policy

### DIFF
--- a/aws/app/ecs_iam.tf
+++ b/aws/app/ecs_iam.tf
@@ -74,8 +74,8 @@ data "aws_iam_policy_document" "forms_s3" {
     ]
 
     resources = [
-      aws_s3_bucket.reliability_file_storage.id,
-      "${aws_s3_bucket.reliability_file_storage.id}/*"
+      aws_s3_bucket.reliability_file_storage.arn,
+      "${aws_s3_bucket.reliability_file_storage.arn}/*"
     ]
   }
 }


### PR DESCRIPTION
# Summary
The IAM policy resources needs to reference the S3 bucket
ARNs and not their IDs.

# Related
* #108 