### PR TITLE
chore: sync templates.js Lambda fix from Staging

### DIFF
--- a/aws/app/lambda/templates/templates.js
+++ b/aws/app/lambda/templates/templates.js
@@ -265,7 +265,8 @@ const createBearerToken = async (dbClient, formID, local, rdsParams) => {
         }
       }
     ];
-    data = await dbClient.send(rdsParamsCopy);
+    const command = new ExecuteStatementCommand(rdsParamsCopy);
+    data = await dbClient.send(command);
     return parseConfig(data.records)
   }
 


### PR DESCRIPTION
# Summary
Sync the fix to the Staging `temlates.js` Lambda to `ExecuteStatementCommand`
which creates a command instead of passing params object templates lambda.
