### PR TITLE
feat: dynamic WAF ACL rules per environment

### DIFF
--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -9,7 +9,7 @@ locals {
   # AWSManagedRulesCommonRuleSet to exclude.  Only exclude XSS in non-production environments.
   excluded_rules_upload = ["GenericRFI_QUERYARGUMENTS", "GenericRFI_BODY", "SizeRestrictions_BODY"]
   excluded_xss          = ["CrossSiteScripting_BODY"]
-  excluded_rules_common = !is_production ? concat(local.excluded_rules_upload, local.excluded_xss) : local.excluded_rules_upload
+  excluded_rules_common = !local.is_production ? concat(local.excluded_rules_upload, local.excluded_xss) : local.excluded_rules_upload
 }
 
 resource "aws_wafv2_web_acl" "forms_acl" {
@@ -119,11 +119,11 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     # Only block in `production`
     action {
       dynamic "block" {
-        for_each = is_production ? [true] : []
+        for_each = local.is_production ? [true] : []
         content {}
       }
       dynamic "count" {
-        for_each = !is_production ? [true] : []
+        for_each = !local.is_production ? [true] : []
         content {}
       }
     }

--- a/aws/load_balancer/waf.tf
+++ b/aws/load_balancer/waf.tf
@@ -2,6 +2,16 @@
 # WAF
 # Defines the firewall rules protecting the ALB
 #
+
+locals {
+  is_production = var.env == "production"
+
+  # AWSManagedRulesCommonRuleSet to exclude.  Only exclude XSS in non-production environments.
+  excluded_rules_upload = ["GenericRFI_QUERYARGUMENTS", "GenericRFI_BODY", "SizeRestrictions_BODY"]
+  excluded_xss          = ["CrossSiteScripting_BODY"]
+  excluded_rules_common = !is_production ? concat(local.excluded_rules_upload, local.excluded_xss) : local.excluded_rules_upload
+}
+
 resource "aws_wafv2_web_acl" "forms_acl" {
   name  = "GCForms"
   scope = "REGIONAL"
@@ -45,20 +55,11 @@ resource "aws_wafv2_web_acl" "forms_acl" {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
 
-        excluded_rule {
-          name = "GenericRFI_QUERYARGUMENTS"
-        }
-
-        excluded_rule {
-          name = "GenericRFI_BODY"
-        }
-
-        excluded_rule {
-          name = "SizeRestrictions_BODY"
-        }
-
-        excluded_rule {
-          name = "CrossSiteScripting_BODY"
+        dynamic "excluded_rule" {
+          for_each = local.excluded_rules_common
+          content {
+            name = excluded_rule.value
+          }
         }
       }
     }
@@ -115,8 +116,16 @@ resource "aws_wafv2_web_acl" "forms_acl" {
     name     = "PostRequestLimit"
     priority = 102
 
+    # Only block in `production`
     action {
-      count {}
+      dynamic "block" {
+        for_each = is_production ? [true] : []
+        content {}
+      }
+      dynamic "count" {
+        for_each = !is_production ? [true] : []
+        content {}
+      }
     }
 
     statement {


### PR DESCRIPTION
# Summary
Allow for dynamic firewall rules depending on the environment:

1. Only block on `PostRequestLimit` exceeded in Production. This
is to support load testing in Staging.

2. Exclude the `CrossSiteScripting_BODY` in Staging.

# Notes
No plan changes are expected since this is the current WAF ACL setup in Staging.

# Related
* #28 
* cds-snc/platform-sre-security-support#47